### PR TITLE
Add CI action to validate `index.json` against schema

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,0 +1,17 @@
+name: Validate index.json
+
+on: [push]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Validate index.json
+        uses: nhalstead/validate-json-action@0.1.3
+        with:
+          schema: ./schema.json
+          jsons: ./index.json
+

--- a/index.json
+++ b/index.json
@@ -140,6 +140,5 @@
       "description": "Stock 4G93 tune with support for limited boost. Some adjustment of CAS maybe needed to align with the trigger angle used",
       "board": "v0.4",
       "filename": "4g93_stock.msq"
-    },
-
+    }
 ]

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,46 @@
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string"
+            },
+            "displayName": {
+                "type": "string"
+            },
+            "make": {
+                "type": "string"
+            },
+            "firmware": {
+                "type": "integer"
+            },
+            "provider": {
+                "type": "string"
+            },
+            "type": {
+                "type": "string"
+            },
+            "board": {
+                "type": "string"
+            },
+            "description": {
+                "type": "string"
+            },
+            "filename": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "id",
+            "displayName",
+            "make",
+            "firmware",
+            "provider",
+            "type",
+            "board",
+            "description",
+            "filename"
+        ]
+    }
+}


### PR DESCRIPTION
I really like the idea of this repo. I've noticed that `index.json` is not a valid json and I thought that we could have CI to check for typical human errors.

This action gives nice feedback, though it doesn't publish comments on PR.

Schema can be checked online: https://www.jsonschemavalidator.net