### PR TITLE
Add CI action to validate `.msq` files against schema

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,6 +1,6 @@
 name: Validate index.json
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   validate:

--- a/.github/workflows/validate-msq.yml
+++ b/.github/workflows/validate-msq.yml
@@ -1,0 +1,17 @@
+name: Validate MSQ
+
+on: [push, pull_request]
+
+jobs:
+  xmllint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Install xmllint
+      run: |
+        sudo apt-get -y --no-install-recommends install libxml2-utils
+    - name: Validate MSQ files
+      run: |
+        find -type f -name "*.msq" -exec xmllint --schema ./schema.xsd --noout {} +

--- a/schema.xsd
+++ b/schema.xsd
@@ -1,0 +1,99 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.msefi.com/:msq" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="msq">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bibliography">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute type="xs:string" name="author"/>
+                <xs:attribute type="xs:string" name="tuneComment"/>
+                <xs:attribute type="xs:string" name="writeDate"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="versionInfo">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute type="xs:float" name="fileFormat"/>
+                <xs:attribute type="xs:string" name="firmwareInfo"/>
+                <xs:attribute type="xs:byte" name="nPages"/>
+                <xs:attribute type="xs:string" name="signature"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="page" maxOccurs="unbounded" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="pcVariable" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute type="xs:string" name="name" use="optional"/>
+                      <xs:attribute type="xs:byte" name="digits" use="optional"/>
+                      <xs:attribute type="xs:string" name="units" use="optional"/>
+                      <xs:attribute type="xs:byte" name="cols" use="optional"/>
+                      <xs:attribute type="xs:short" name="rows" use="optional"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="constant" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute type="xs:byte" name="digits" use="optional"/>
+                      <xs:attribute type="xs:string" name="name" use="optional"/>
+                      <xs:attribute type="xs:string" name="units" use="optional"/>
+                      <xs:attribute type="xs:byte" name="cols" use="optional"/>
+                      <xs:attribute type="xs:byte" name="rows" use="optional"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute type="xs:byte" name="number" use="optional"/>
+            <xs:attribute type="xs:short" name="size" use="optional"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="settings">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="setting" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute type="xs:string" name="name" use="optional"/>
+                      <xs:attribute type="xs:string" name="value" use="optional"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="Comment"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="userComments">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="userComment" maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute type="xs:string" name="name" use="optional"/>
+                      <xs:attribute type="xs:string" name="value" use="optional"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="Comment"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This action also gives nice feedback to the contributor. 

This XSD schema is generated using https://www.freeformatter.com/xsd-generator.html, though it might not be complete for MSQ, all tunes are passing right now.

---

Example below shows a tag with invalid name (`pcVariables` instead of `pcVariable`):

<img width="1253" alt="Screenshot 2021-11-10 at 23 59 35" src="https://user-images.githubusercontent.com/3144291/141207772-2d1241e8-90bc-44ce-afb4-5b5318311063.png">


