### PR TITLE
Update BMW tunes to 202305

### DIFF
--- a/BMW/M43_PnP.msq
+++ b/BMW/M43_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 10:34:42 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">3000.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">5000.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -470,18 +473,14 @@
 <constant digits="0" name="maeThresh" units="kPa/s">20.0</constant>
 <constant digits="0" name="taeThresh" units="%/s">10.0</constant>
 <constant digits="0" name="aeTime" units="ms">30.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">15.8</constant>
 <constant digits="0" name="divider">2.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"No"</constant>
+<constant name="crkngAddCLTAdv">"Yes"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
@@ -521,14 +520,14 @@
 <constant digits="0" name="oddfire2" units="deg">0.0</constant>
 <constant digits="0" name="oddfire3" units="deg">0.0</constant>
 <constant digits="0" name="oddfire4" units="deg">0.0</constant>
-<constant name="idleUpPin">"36"</constant>
+<constant name="idleUpPin">"21"</constant>
 <constant name="idleUpPolarity">"Inverted"</constant>
 <constant name="idleUpEnabled">"Off"</constant>
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
 <constant digits="0" name="aeTaperMax" units="RPM">3500.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">30.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">80.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">0.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">0.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">1.0</constant>
 <constant digits="0" name="baroMax" units="kpa">315.0</constant>
@@ -589,7 +588,7 @@
 <constant digits="0" name="dfcoMinCLT" units="C">50.0</constant>
 <constant name="vssMode">"Off"</constant>
 <constant name="vssPin">"Board Default"</constant>
-<constant digits="0" name="vssPulsesPerKm" units="pulses">11.0</constant>
+<constant digits="0" name="vssPulsesPerKm" units="pulses">0.0</constant>
 <constant digits="0" name="vssSmoothing" units="%">50.0</constant>
 <constant digits="1" name="vssRatio1" units="km/h per 1000rpm">0.0</constant>
 <constant digits="1" name="vssRatio2" units="km/h per 1000rpm">0.0</constant>
@@ -607,10 +606,12 @@
 <constant digits="0" name="rtc_trim" units="ppm">0.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">0.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1400.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
@@ -757,7 +758,7 @@
 <constant digits="0" name="SoftRevLim" units="rpm">5500.0</constant>
 <constant digits="0" name="SoftLimRetard" units="deg">6.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">5.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">6000.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7000.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
          10.0 
          220.0 
@@ -888,6 +889,8 @@
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">2000.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">0.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
+<constant name="inj4CylPairing">"1+3 &amp; 2+4"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
 <constant name="unusedBits4_123">"0"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">4.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">0.0</constant>
@@ -895,6 +898,24 @@
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 0.9931973 
+         0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 0.9863946 
+         0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 0.9795918 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9659864 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 0.9727891 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 0.9591837 
+         0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 0.952381 
+         0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 0.9387755 
+         0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 0.9319728 
+         0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 0.9251701 
+         0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -968,8 +989,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"Off"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.6122449</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.292517</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -977,7 +1000,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Simple"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"No"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          6.0 
@@ -1117,7 +1140,7 @@
 <constant digits="0" name="iacStepHyster" units="Steps">5.0</constant>
 <constant name="fanInv">"No"</constant>
 <constant name="fanUnused">"Off"</constant>
-<constant name="fanPin">"46"</constant>
+<constant name="fanPin">"Board Default"</constant>
 <constant digits="0" name="fanSP" units="C">75.0</constant>
 <constant digits="0" name="fanHyster" units="C">2.0</constant>
 <constant digits="0" name="fanFreq" units="Hz">6.0</constant>
@@ -1546,7 +1569,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">248.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">248.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1627,7 +1650,7 @@
 <constant name="iacCoolTime">"6"</constant>
 <constant name="boostByGearEnabled">"Constant limit"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">78.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1" units="Limit">0.0</constant>
@@ -1642,27 +1665,24 @@
          13.5 
          40.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
-         0.0 
-         21.0 
-         44.0 
-         45.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+      </constant>
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
@@ -1670,6 +1690,14 @@
          7.0 
          7.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.0952381</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.7</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">3.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1767,6 +1795,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">510.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">127.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">25.5</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.7346939</constant>
 <constant name="n2o_stage1_pin">"7"</constant>
 <constant name="n2o_pin_polarity">"HIGH"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1843,18 +1872,18 @@
 <constant name="oilPressureProtEnbl">"Off"</constant>
 <constant name="oilPressurePin">"A0"</constant>
 <constant name="fuelPressurePin">"A0"</constant>
-<constant digits="0" name="fuelPressureMin" units="psi">9.0</constant>
-<constant digits="0" name="fuelPressureMax" units="psi">47.0</constant>
-<constant digits="0" name="oilPressureMin" units="psi">116.0</constant>
-<constant digits="0" name="oilPressureMax" units="psi">33.0</constant>
-<constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
-         500.0 
+<constant digits="2" name="fuelPressureMin" units="BAR">-8.8646</constant>
+<constant digits="2" name="fuelPressureMax" units="BAR">11.2378</constant>
+<constant digits="2" name="oilPressureMin" units="BAR">8.7948</constant>
+<constant digits="2" name="oilPressureMax" units="BAR">15.1466</constant>
+<constant cols="1" digits="2" name="oilPressureProtMins" rows="4" units="BAR">
+         0.0 
          0.0 
          0.0 
          0.0 
       </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
-         0.0 
+<constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
+         500.0 
          0.0 
          0.0 
          0.0 
@@ -1919,9 +1948,9 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         1500.0 
-         500.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
+         0.0 
       </constant>
 </page>
 <page number="10" size="288">
@@ -2053,11 +2082,11 @@
          3000.0 
          4000.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
-         10.0 
-         50.0 
-         100.0 
-         200.0 
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
+         510.0 
+         510.0 
+         510.0 
+         510.0 
       </constant>
 <constant cols="1" digits="0" name="UNALLOCATED_TOP_11" rows="8" units="RAW">
          0.0 
@@ -2240,7 +2269,7 @@
 <constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
 <constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
 <constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant name="unused13_125_2">"space"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
          255.0 
          255.0 
@@ -2302,8 +2331,230 @@
          100.0 
       </constant>
 </page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
+         2000.0 
+         2500.0 
+         3000.0 
+         3500.0 
+         4000.0 
+         4500.0 
+         5000.0 
+      </constant>
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Disabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">50.0</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">600.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">4000.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">110.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">5.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">2.0</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">0.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">5.0</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">2.0</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">100.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">40.0</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+      </constant>
+</page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
+<setting name="pressure_bar" value="pressure_bar"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>

--- a/BMW/M50NV_PnP.msq
+++ b/BMW/M50NV_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 10:50:52 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">5500.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">6500.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -470,18 +473,14 @@
 <constant digits="0" name="maeThresh" units="kPa/s">255.0</constant>
 <constant digits="0" name="taeThresh" units="%/s">20.0</constant>
 <constant digits="0" name="aeTime" units="ms">20.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">14.7</constant>
 <constant digits="0" name="divider">3.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"Yes"</constant>
+<constant name="crkngAddCLTAdv">"Yes"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
@@ -521,14 +520,14 @@
 <constant digits="0" name="oddfire2" units="deg">0.0</constant>
 <constant digits="0" name="oddfire3" units="deg">0.0</constant>
 <constant digits="0" name="oddfire4" units="deg">0.0</constant>
-<constant name="idleUpPin">"13"</constant>
+<constant name="idleUpPin">"21"</constant>
 <constant name="idleUpPolarity">"Inverted"</constant>
 <constant name="idleUpEnabled">"Off"</constant>
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
 <constant digits="0" name="aeTaperMax" units="RPM">5000.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">0.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">0.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">0.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">0.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">10.0</constant>
 <constant digits="0" name="baroMax" units="kpa">118.0</constant>
@@ -589,7 +588,7 @@
 <constant digits="0" name="dfcoMinCLT" units="C">30.0</constant>
 <constant name="vssMode">"Off"</constant>
 <constant name="vssPin">"3"</constant>
-<constant digits="0" name="vssPulsesPerKm" units="pulses">11.0</constant>
+<constant digits="0" name="vssPulsesPerKm" units="pulses">0.0</constant>
 <constant digits="0" name="vssSmoothing" units="%">20.0</constant>
 <constant digits="1" name="vssRatio1" units="km/h per 1000rpm">0.0</constant>
 <constant digits="1" name="vssRatio2" units="km/h per 1000rpm">0.0</constant>
@@ -607,10 +606,12 @@
 <constant digits="0" name="rtc_trim" units="ppm">0.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">0.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1400.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
@@ -757,7 +758,7 @@
 <constant digits="0" name="SoftRevLim" units="rpm">6500.0</constant>
 <constant digits="0" name="SoftLimRetard" units="deg">10.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">2.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">7000.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7000.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
          10.0 
          260.0 
@@ -888,6 +889,8 @@
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">1600.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">0.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
+<constant name="inj4CylPairing">"1+3 &amp; 2+4"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
 <constant name="unusedBits4_123">"0"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">4.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">0.0</constant>
@@ -895,6 +898,24 @@
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0136054 1.0204082 1.0204082 1.0068027 1.0 1.0 1.0 0.9931973 0.9863946 0.9863946 0.9795918 0.9795918 
+         1.0 1.0 1.0 1.0 1.0068027 1.0136054 1.0136054 1.0 0.9931973 0.9863946 0.9795918 0.9727891 0.9659864 0.952381 0.952381 0.952381 
+         0.9863946 0.9863946 0.9863946 0.9863946 0.9931973 1.0 1.0 0.9863946 0.9795918 0.9727891 0.9727891 0.9659864 0.9591837 0.9455782 0.9455782 0.9455782 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9795918 0.9795918 0.9795918 0.9727891 0.9659864 0.9659864 0.9591837 0.952381 0.952381 0.9387755 0.9387755 0.9387755 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9659864 0.9659864 0.9659864 0.9591837 0.9591837 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 
+         0.9455782 0.9455782 0.9455782 0.9455782 0.9455782 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 0.9319728 0.9319728 0.9319728 0.9319728 
+         0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 
+         0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 
+         0.8979592 0.8979592 0.8979592 0.8979592 0.8979592 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 
+         0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.877551 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -968,8 +989,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"On"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.6122449</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.292517</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -977,7 +1000,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Full"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"No"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          8.0 
@@ -1546,7 +1569,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">255.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">255.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1627,7 +1650,7 @@
 <constant name="iacCoolTime">"0"</constant>
 <constant name="boostByGearEnabled">"Constant limit"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">21.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1" units="Limit">0.0</constant>
@@ -1642,27 +1665,24 @@
          13.5 
          40.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
-         0.0 
-         21.0 
-         44.0 
-         45.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+      </constant>
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
@@ -1670,6 +1690,14 @@
          7.0 
          7.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.0952381</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.7</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">3.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1767,6 +1795,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">250.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">30.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">18.0</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.2244898</constant>
 <constant name="n2o_stage1_pin">"30"</constant>
 <constant name="n2o_pin_polarity">"LOW"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1843,21 +1872,21 @@
 <constant name="oilPressureProtEnbl">"Off"</constant>
 <constant name="oilPressurePin">"A12"</constant>
 <constant name="fuelPressurePin">"A5"</constant>
-<constant digits="0" name="fuelPressureMin" units="psi">52.0</constant>
-<constant digits="0" name="fuelPressureMax" units="psi">158.0</constant>
-<constant digits="0" name="oilPressureMin" units="psi">-66.0</constant>
-<constant digits="0" name="oilPressureMax" units="psi">62.0</constant>
+<constant digits="2" name="fuelPressureMin" units="BAR">-1.6054</constant>
+<constant digits="2" name="fuelPressureMax" units="BAR">15.0768</constant>
+<constant digits="2" name="oilPressureMin" units="BAR">5.4444</constant>
+<constant digits="2" name="oilPressureMax" units="BAR">8.376</constant>
+<constant cols="1" digits="2" name="oilPressureProtMins" rows="4" units="BAR">
+         6.98 
+         14.0298 
+         7.2592 
+         9.2834 
+      </constant>
 <constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
          800.0 
          2000.0 
          4000.0 
          7000.0 
-      </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
-         7.0 
-         14.0 
-         43.0 
-         45.0 
       </constant>
 <constant name="wmiEnabled">"Off"</constant>
 <constant name="wmiMode">"Openloop"</constant>
@@ -1919,9 +1948,9 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         1500.0 
-         500.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
+         0.0 
       </constant>
 </page>
 <page number="10" size="288">
@@ -2053,11 +2082,11 @@
          3000.0 
          4000.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
-         10.0 
-         50.0 
-         100.0 
-         200.0 
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
+         510.0 
+         510.0 
+         510.0 
+         510.0 
       </constant>
 <constant cols="1" digits="0" name="UNALLOCATED_TOP_11" rows="8" units="RAW">
          0.0 
@@ -2242,7 +2271,7 @@
 <constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
 <constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
 <constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant name="unused13_125_2">"space"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
          255.0 
          255.0 
@@ -2304,12 +2333,233 @@
          240.0 
       </constant>
 </page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
+         2000.0 
+         2500.0 
+         3000.0 
+         3500.0 
+         4000.0 
+         4500.0 
+         5000.0 
+      </constant>
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Disabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">50.0</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">600.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">4000.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">110.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">5.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">2.0</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">0.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">5.0</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">2.0</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">100.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">40.0</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+      </constant>
+</page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
+<setting name="pressure_bar" value="pressure_bar"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>
-<setting name="mcu_stm32" value="mcu_stm32"/>
 <setting name="resetcontrol_standard" value="resetcontrol_standard"/>
 <setting name="AFR" value="AFR"/>
 </settings>

--- a/BMW/M50TU_PnP.msq
+++ b/BMW/M50TU_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 10:52:38 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">5500.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">6500.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -470,18 +473,14 @@
 <constant digits="0" name="maeThresh" units="kPa/s">255.0</constant>
 <constant digits="0" name="taeThresh" units="%/s">20.0</constant>
 <constant digits="0" name="aeTime" units="ms">20.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">14.7</constant>
 <constant digits="0" name="divider">3.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"Yes"</constant>
+<constant name="crkngAddCLTAdv">"Yes"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
@@ -521,14 +520,14 @@
 <constant digits="0" name="oddfire2" units="deg">0.0</constant>
 <constant digits="0" name="oddfire3" units="deg">0.0</constant>
 <constant digits="0" name="oddfire4" units="deg">0.0</constant>
-<constant name="idleUpPin">"13"</constant>
+<constant name="idleUpPin">"21"</constant>
 <constant name="idleUpPolarity">"Inverted"</constant>
 <constant name="idleUpEnabled">"Off"</constant>
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
 <constant digits="0" name="aeTaperMax" units="RPM">5000.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">0.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">0.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">0.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">0.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">10.0</constant>
 <constant digits="0" name="baroMax" units="kpa">118.0</constant>
@@ -589,7 +588,7 @@
 <constant digits="0" name="dfcoMinCLT" units="C">30.0</constant>
 <constant name="vssMode">"Off"</constant>
 <constant name="vssPin">"3"</constant>
-<constant digits="0" name="vssPulsesPerKm" units="pulses">11.0</constant>
+<constant digits="0" name="vssPulsesPerKm" units="pulses">0.0</constant>
 <constant digits="0" name="vssSmoothing" units="%">20.0</constant>
 <constant digits="1" name="vssRatio1" units="km/h per 1000rpm">0.0</constant>
 <constant digits="1" name="vssRatio2" units="km/h per 1000rpm">0.0</constant>
@@ -607,10 +606,12 @@
 <constant digits="0" name="rtc_trim" units="ppm">0.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">0.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1400.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
@@ -757,7 +758,7 @@
 <constant digits="0" name="SoftRevLim" units="rpm">6500.0</constant>
 <constant digits="0" name="SoftLimRetard" units="deg">10.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">2.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">7000.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7000.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
          10.0 
          260.0 
@@ -888,6 +889,8 @@
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">1600.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">0.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
+<constant name="inj4CylPairing">"1+3 &amp; 2+4"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
 <constant name="unusedBits4_123">"0"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">4.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">0.0</constant>
@@ -895,6 +898,24 @@
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0136054 1.0204082 1.0204082 1.0068027 1.0 1.0 1.0 0.9931973 0.9863946 0.9863946 0.9795918 0.9795918 
+         1.0 1.0 1.0 1.0 1.0068027 1.0136054 1.0136054 1.0 0.9931973 0.9863946 0.9795918 0.9727891 0.9659864 0.952381 0.952381 0.952381 
+         0.9863946 0.9863946 0.9863946 0.9863946 0.9931973 1.0 1.0 0.9863946 0.9795918 0.9727891 0.9727891 0.9659864 0.9591837 0.9455782 0.9455782 0.9455782 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9795918 0.9795918 0.9795918 0.9727891 0.9659864 0.9659864 0.9591837 0.952381 0.952381 0.9387755 0.9387755 0.9387755 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9659864 0.9659864 0.9659864 0.9591837 0.9591837 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 
+         0.9455782 0.9455782 0.9455782 0.9455782 0.9455782 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 0.9319728 0.9319728 0.9319728 0.9319728 
+         0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 
+         0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 
+         0.8979592 0.8979592 0.8979592 0.8979592 0.8979592 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 
+         0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.877551 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -968,8 +989,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"On"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.6122449</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.292517</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -977,7 +1000,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Full"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"No"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          8.0 
@@ -1546,7 +1569,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">255.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">255.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1627,7 +1650,7 @@
 <constant name="iacCoolTime">"0"</constant>
 <constant name="boostByGearEnabled">"Constant limit"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">21.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1" units="Limit">0.0</constant>
@@ -1642,27 +1665,24 @@
          13.5 
          40.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
-         0.0 
-         21.0 
-         44.0 
-         45.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+      </constant>
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
@@ -1670,6 +1690,14 @@
          7.0 
          7.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.0952381</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.7</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">3.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1767,6 +1795,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">250.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">30.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">18.0</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.2244898</constant>
 <constant name="n2o_stage1_pin">"30"</constant>
 <constant name="n2o_pin_polarity">"LOW"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1843,21 +1872,21 @@
 <constant name="oilPressureProtEnbl">"Off"</constant>
 <constant name="oilPressurePin">"A12"</constant>
 <constant name="fuelPressurePin">"A5"</constant>
-<constant digits="0" name="fuelPressureMin" units="psi">52.0</constant>
-<constant digits="0" name="fuelPressureMax" units="psi">158.0</constant>
-<constant digits="0" name="oilPressureMin" units="psi">-66.0</constant>
-<constant digits="0" name="oilPressureMax" units="psi">62.0</constant>
+<constant digits="2" name="fuelPressureMin" units="BAR">-1.6054</constant>
+<constant digits="2" name="fuelPressureMax" units="BAR">15.0768</constant>
+<constant digits="2" name="oilPressureMin" units="BAR">5.4444</constant>
+<constant digits="2" name="oilPressureMax" units="BAR">8.376</constant>
+<constant cols="1" digits="2" name="oilPressureProtMins" rows="4" units="BAR">
+         6.98 
+         14.0298 
+         7.2592 
+         9.2834 
+      </constant>
 <constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
          800.0 
          2000.0 
          4000.0 
          7000.0 
-      </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
-         7.0 
-         14.0 
-         43.0 
-         45.0 
       </constant>
 <constant name="wmiEnabled">"Off"</constant>
 <constant name="wmiMode">"Openloop"</constant>
@@ -1919,9 +1948,9 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         1500.0 
-         500.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
+         0.0 
       </constant>
 </page>
 <page number="10" size="288">
@@ -2053,11 +2082,11 @@
          3000.0 
          4000.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
-         10.0 
-         50.0 
-         100.0 
-         200.0 
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
+         510.0 
+         510.0 
+         510.0 
+         510.0 
       </constant>
 <constant cols="1" digits="0" name="UNALLOCATED_TOP_11" rows="8" units="RAW">
          0.0 
@@ -2241,7 +2270,7 @@
 <constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
 <constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
 <constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant name="unused13_125_2">"space"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
          255.0 
          255.0 
@@ -2303,8 +2332,230 @@
          240.0 
       </constant>
 </page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
+         2000.0 
+         2500.0 
+         3000.0 
+         3500.0 
+         4000.0 
+         4500.0 
+         5000.0 
+      </constant>
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Disabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">50.0</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">600.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">4000.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">110.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">5.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">2.0</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">0.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">5.0</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">2.0</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">100.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">40.0</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+      </constant>
+</page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
+<setting name="pressure_bar" value="pressure_bar"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>

--- a/BMW/M52TU_PnP.msq
+++ b/BMW/M52TU_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 15:33:26 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+2023.05" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">3000.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">5000.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -23,14 +26,14 @@
          0.0 
       </pcVariable>
 <pcVariable cols="1" digits="0" name="wueRecommended" rows="10" units="%">
-         208.0 
-         199.0 
-         158.0 
-         147.0 
-         139.0 
-         123.0 
-         112.0 
-         105.0 
+         180.0 
+         171.0 
+         133.0 
+         124.0 
+         116.0 
+         113.0 
+         109.0 
+         107.0 
          100.0 
          100.0 
       </pcVariable>
@@ -434,21 +437,19 @@
          100.0 
          100.0 
       </pcVariable>
-<pcVariable name="prgm_out_selection">"2"</pcVariable>
+<pcVariable name="prgm_out_selection">"1"</pcVariable>
 <pcVariable digits="0" name="fuelLoadMax">255.0</pcVariable>
 <pcVariable digits="0" name="ignLoadMax">255.0</pcVariable>
 <pcVariable digits="0" name="fuel2LoadMax">255.0</pcVariable>
 <pcVariable digits="0" name="ign2LoadMax">255.0</pcVariable>
 <pcVariable name="AUXin00Alias">Oil temp RAW</pcVariable>
+<pcVariable name="AUXin01Alias">Rad temp RAW</pcVariable>
 <pcVariable name="AUXin02Alias">VSS1</pcVariable>
 <pcVariable name="AUXin03Alias">VSS2</pcVariable>
 <pcVariable name="AUXin04Alias">VSS3</pcVariable>
 <pcVariable name="AUXin05Alias">VSS4</pcVariable>
 <pcVariable name="prgm_out00Alias">DISA</pcVariable>
 <pcVariable name="prgm_out01Alias">E-thermostat</pcVariable>
-<pcVariable name="prgm_out05Alias">PrgmOut5</pcVariable>
-<pcVariable name="prgm_out06Alias">PrgmOut6</pcVariable>
-<pcVariable name="prgm_out07Alias">PrgmOut7</pcVariable>
 </page>
 <page number="0" size="128">
 <constant digits="1" name="aseTaperTime" units="S">5.0</constant>
@@ -456,7 +457,7 @@
 <constant digits="0" name="aeColdTaperMin" units="C">-15.0</constant>
 <constant name="aeMode">"TPS"</constant>
 <constant name="battVCorMode">"Open Time only"</constant>
-<constant name="SoftLimitMode">"Fixed"</constant>
+<constant name="SoftLimitMode">"Relative "</constant>
 <constant name="useTachoSweep">"Off"</constant>
 <constant name="aeApplyMode">"PW Adder"</constant>
 <constant name="multiplyMAP">"Fixed"</constant>
@@ -478,30 +479,26 @@
 <constant name="tachoDiv">"Normal"</constant>
 <constant digits="0" name="tachoDuration" units="ms">1.0</constant>
 <constant digits="0" name="maeThresh" units="kPa/s">255.0</constant>
-<constant digits="0" name="taeThresh" units="%/s">4.0</constant>
-<constant digits="0" name="aeTime" units="ms">30.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="0" name="taeThresh" units="%/s">6.0</constant>
+<constant digits="0" name="aeTime" units="ms">200.0</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">16.5</constant>
 <constant digits="0" name="divider">3.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"No"</constant>
+<constant name="crkngAddCLTAdv">"No"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
 <constant name="indInjAng">"Disabled"</constant>
 <constant digits="1" name="injOpen" units="ms">0.6</constant>
 <constant cols="1" digits="0" name="injAng" rows="4" units="deg">
-         355.0 
-         355.0 
-         355.0 
-         355.0 
+         300.0 
+         300.0 
+         300.0 
+         300.0 
       </constant>
 <constant name="mapSample">"Cycle Average"</constant>
 <constant name="twoStroke">"Four-stroke"</constant>
@@ -522,8 +519,8 @@
 <constant digits="0" name="flexFreqLow" units="Hz">50.0</constant>
 <constant digits="0" name="flexFreqHigh" units="Hz">150.0</constant>
 <constant digits="0" name="boostMaxDuty" units="%">80.0</constant>
-<constant digits="0" name="tpsMin" units="ADC">45.0</constant>
-<constant digits="0" name="tpsMax" units="ADC">213.0</constant>
+<constant digits="0" name="tpsMin" units="ADC">42.0</constant>
+<constant digits="0" name="tpsMax" units="ADC">206.0</constant>
 <constant digits="0" name="mapMin" units="kpa">3.0</constant>
 <constant digits="0" name="mapMax" units="kpa">416.0</constant>
 <constant digits="0" name="fpPrime" units="s">2.0</constant>
@@ -536,9 +533,9 @@
 <constant name="idleUpEnabled">"Off"</constant>
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
-<constant digits="0" name="aeTaperMax" units="RPM">5000.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">0.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">0.0</constant>
+<constant digits="0" name="aeTaperMax" units="RPM">6000.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">24.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">44.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">10.0</constant>
 <constant digits="0" name="baroMax" units="kpa">118.0</constant>
@@ -547,7 +544,7 @@
 <constant name="fanWhenOff">"Yes"</constant>
 <constant name="fanWhenCranking">"No"</constant>
 <constant name="useDwellMap">"No"</constant>
-<constant name="fanEnable">"Off"</constant>
+<constant name="fanEnable">"PWM"</constant>
 <constant name="rtc_mode">"Off"</constant>
 <constant name="incorporateAFR">"No"</constant>
 <constant cols="1" digits="0" name="asePct" rows="4" units="%">
@@ -558,7 +555,7 @@
       </constant>
 <constant cols="1" digits="0" name="aseCount" rows="4" units="s">
          30.0 
-         12.0 
+         16.0 
          5.0 
          3.0 
       </constant>
@@ -589,9 +586,9 @@
 <constant digits="0" name="idleAdvRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="idleAdvTPS" units="%">1.0</constant>
 <constant cols="1" digits="0" name="injAngRPM" rows="4" units="RPM">
-         500.0 
-         2000.0 
-         4500.0 
+         900.0 
+         3800.0 
+         4900.0 
          6500.0 
       </constant>
 <constant digits="1" name="idleTaperTime" units="S">0.1</constant>
@@ -612,40 +609,43 @@
 <constant name="idleUpOutputPin">"Board Default"</constant>
 <constant digits="0" name="tachoSweepMaxRPM" units="RPM">25500.0</constant>
 <constant digits="1" name="primingDelay" units="S">0.7</constant>
-<constant digits="1" name="iacTPSlimit" units="%">127.0</constant>
-<constant digits="0" name="iacRPMlimitHysteresis" units="RPM">2550.0</constant>
+<constant digits="1" name="iacTPSlimit" units="%">0.5</constant>
+<constant digits="0" name="iacRPMlimitHysteresis" units="RPM">90.0</constant>
 <constant digits="0" name="rtc_trim" units="ppm">-1.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">255.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1500.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
-         46.0 47.0 48.0 52.0 52.0 43.0 46.0 34.0 30.0 23.0 27.0 34.0 25.0 34.0 58.0 57.0 
-         44.0 47.0 47.0 52.0 52.0 53.0 56.0 57.0 56.0 49.0 66.0 66.0 59.0 56.0 60.0 59.0 
-         44.0 45.0 45.0 50.0 53.0 54.0 58.0 58.0 61.0 55.0 72.0 74.0 65.0 65.0 64.0 63.0 
-         46.0 47.0 47.0 49.0 53.0 55.0 56.0 58.0 59.0 58.0 76.0 77.0 70.0 69.0 65.0 64.0 
-         48.0 48.0 47.0 49.0 54.0 55.0 57.0 58.0 59.0 61.0 75.0 77.0 68.0 72.0 70.0 69.0 
-         52.0 56.0 53.0 53.0 57.0 58.0 59.0 61.0 62.0 65.0 74.0 76.0 68.0 75.0 74.0 73.0 
-         55.0 58.0 60.0 59.0 61.0 63.0 63.0 67.0 70.0 75.0 80.0 84.0 82.0 80.0 79.0 78.0 
-         56.0 64.0 62.0 62.0 66.0 67.0 68.0 72.0 75.0 80.0 86.0 89.0 86.0 81.0 85.0 84.0 
-         57.0 66.0 65.0 66.0 67.0 70.0 71.0 77.0 82.0 88.0 95.0 97.0 92.0 87.0 88.0 87.0 
-         58.0 66.0 68.0 72.0 67.0 73.0 78.0 82.0 85.0 89.0 98.0 101.0 95.0 92.0 92.0 91.0 
-         61.0 66.0 70.0 70.0 70.0 78.0 81.0 87.0 89.0 95.0 99.0 99.0 95.0 99.0 97.0 96.0 
-         63.0 68.0 69.0 70.0 72.0 81.0 87.0 92.0 91.0 98.0 100.0 98.0 97.0 102.0 97.0 96.0 
-         65.0 70.0 71.0 72.0 74.0 83.0 89.0 94.0 93.0 100.0 102.0 100.0 99.0 104.0 99.0 98.0 
-         67.0 72.0 73.0 74.0 76.0 85.0 91.0 96.0 95.0 102.0 104.0 102.0 101.0 106.0 101.0 100.0 
-         69.0 74.0 75.0 76.0 78.0 87.0 93.0 98.0 97.0 104.0 106.0 104.0 103.0 108.0 103.0 102.0 
-         71.0 76.0 77.0 78.0 80.0 89.0 95.0 100.0 99.0 106.0 108.0 106.0 105.0 110.0 105.0 104.0 
+         46.0 46.0 47.0 50.0 50.0 52.0 57.0 58.0 56.0 58.0 58.0 71.0 70.0 60.0 61.0 55.0 
+         46.0 46.0 47.0 48.0 48.0 51.0 55.0 58.0 53.0 54.0 54.0 70.0 73.0 68.0 66.0 55.0 
+         46.0 47.0 46.0 47.0 47.0 51.0 57.0 56.0 53.0 54.0 53.0 67.0 70.0 71.0 67.0 55.0 
+         47.0 47.0 47.0 46.0 47.0 50.0 53.0 55.0 52.0 55.0 63.0 70.0 78.0 78.0 68.0 59.0 
+         50.0 49.0 48.0 48.0 51.0 51.0 53.0 55.0 56.0 57.0 64.0 70.0 79.0 80.0 70.0 61.0 
+         53.0 50.0 48.0 47.0 50.0 52.0 55.0 57.0 57.0 58.0 59.0 71.0 81.0 82.0 75.0 68.0 
+         52.0 54.0 51.0 51.0 52.0 57.0 58.0 59.0 62.0 64.0 66.0 75.0 81.0 83.0 78.0 68.0 
+         55.0 55.0 53.0 52.0 55.0 58.0 59.0 60.0 63.0 66.0 70.0 77.0 82.0 85.0 80.0 71.0 
+         57.0 56.0 54.0 53.0 57.0 59.0 59.0 60.0 64.0 67.0 72.0 78.0 82.0 86.0 81.0 73.0 
+         56.0 58.0 58.0 57.0 59.0 61.0 60.0 59.0 68.0 71.0 75.0 82.0 86.0 89.0 85.0 76.0 
+         53.0 60.0 62.0 62.0 60.0 63.0 65.0 67.0 74.0 73.0 82.0 89.0 86.0 92.0 90.0 80.0 
+         58.0 65.0 67.0 68.0 67.0 72.0 74.0 73.0 79.0 79.0 86.0 93.0 91.0 97.0 96.0 86.0 
+         62.0 69.0 70.0 72.0 73.0 73.0 80.0 90.0 93.0 93.0 101.0 99.0 97.0 101.0 101.0 95.0 
+         64.0 71.0 71.0 73.0 74.0 73.0 83.0 94.0 94.0 94.0 100.0 99.0 96.0 102.0 102.0 94.0 
+         65.0 72.0 71.0 73.0 75.0 73.0 85.0 96.0 95.0 95.0 100.0 99.0 96.0 103.0 102.0 93.0 
+         65.0 72.0 71.0 73.0 75.0 73.0 85.0 96.0 95.0 95.0 100.0 99.0 96.0 103.0 102.0 93.0 
       </constant>
 <constant cols="1" digits="0" name="rpmBins" rows="16" units="RPM">
          700.0 
          900.0 
          1100.0 
-         1400.0 
+         1300.0 
+         1500.0 
          1700.0 
          2000.0 
          2300.0 
@@ -656,52 +656,52 @@
          4500.0 
          5000.0 
          6000.0 
-         7000.0 
-         7500.0 
+         7200.0 
       </constant>
 <constant cols="1" digits="0" name="fuelLoadBins" rows="16" units="kPa">
+         10.0 
          16.0 
          20.0 
          26.0 
          30.0 
          36.0 
          40.0 
+         46.0 
          50.0 
          60.0 
          70.0 
          80.0 
          90.0 
+         96.0 
          100.0 
          110.0 
-         120.0 
-         130.0 
-         140.0 
       </constant>
 </page>
 <page number="2" size="288">
 <constant cols="16" digits="0" name="advTable1" rows="16" units="deg">
-         13.0 11.0 12.0 17.0 20.0 22.0 22.0 28.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 
-         13.0 11.0 13.0 17.0 20.0 21.0 24.0 29.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 
-         13.0 11.0 13.0 17.0 19.0 21.0 24.0 28.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 
-         13.0 11.0 13.0 17.0 19.0 21.0 24.0 29.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 
-         13.0 11.0 13.0 17.0 19.0 21.0 23.0 27.0 29.0 31.0 31.0 31.0 31.0 31.0 31.0 31.0 
-         13.0 11.0 12.0 17.0 18.0 20.0 22.0 26.0 29.0 30.0 32.0 31.0 30.0 30.0 30.0 30.0 
-         12.0 10.0 11.0 14.0 16.0 18.0 20.0 24.0 26.0 27.0 30.0 31.0 31.0 31.0 31.0 31.0 
-         11.0 10.0 9.0 13.0 15.0 16.0 18.0 22.0 24.0 26.0 29.0 29.0 29.0 29.0 29.0 29.0 
-         9.0 8.0 8.0 12.0 14.0 15.0 17.0 19.0 22.0 24.0 26.0 28.0 28.0 28.0 30.0 29.0 
-         7.0 8.0 7.0 11.0 13.0 14.0 15.0 17.0 18.0 20.0 23.0 26.0 28.0 28.0 29.0 28.0 
-         3.0 6.0 4.0 10.0 12.0 13.0 14.0 15.0 16.0 19.0 22.0 25.0 27.0 27.0 28.0 28.0 
-         1.0 2.0 2.0 8.0 11.0 13.0 13.0 14.0 15.0 16.0 20.0 23.0 25.0 25.0 26.0 28.0 
-         0.0 2.0 2.0 6.0 11.0 12.0 13.0 13.0 15.0 17.0 20.0 22.0 24.0 25.0 26.0 27.0 
-         -5.0 -4.0 3.0 6.0 8.0 10.0 12.0 13.0 15.0 16.0 18.0 21.0 23.0 23.0 24.0 24.0 
-         -7.0 -5.0 2.0 4.0 6.0 9.0 10.0 12.0 13.0 15.0 17.0 19.0 21.0 22.0 23.0 23.0 
-         -7.0 -6.0 0.0 2.0 4.0 7.0 9.0 10.0 11.0 13.0 15.0 17.0 19.0 20.0 21.0 21.0 
+         12.0 11.0 13.0 16.0 19.0 20.0 22.0 22.0 28.0 30.0 30.0 30.0 30.0 30.0 30.0 30.0 
+         12.0 11.0 13.0 16.0 19.0 21.0 23.0 23.0 28.0 30.0 30.0 30.0 30.0 30.0 30.0 30.0 
+         12.0 11.0 14.0 17.0 19.0 21.0 22.0 25.0 30.0 32.0 32.0 32.0 32.0 32.0 32.0 32.0 
+         12.0 11.0 14.0 17.0 19.0 20.0 22.0 25.0 29.0 32.0 32.0 32.0 32.0 32.0 32.0 32.0 
+         12.0 11.0 14.0 17.0 19.0 20.0 22.0 25.0 30.0 32.0 32.0 32.0 32.0 32.0 32.0 32.0 
+         12.0 11.0 14.0 17.0 19.0 20.0 22.0 24.0 28.0 30.0 32.0 32.0 32.0 32.0 32.0 32.0 
+         12.0 12.0 13.0 16.0 18.0 19.0 21.0 23.0 27.0 30.0 31.0 33.0 32.0 31.0 31.0 31.0 
+         11.0 11.0 12.0 14.0 16.0 17.0 19.0 21.0 25.0 27.0 28.0 31.0 32.0 32.0 32.0 32.0 
+         11.0 11.0 10.0 13.0 15.0 16.0 17.0 19.0 23.0 25.0 27.0 30.0 30.0 30.0 30.0 30.0 
+         10.0 9.0 9.0 12.0 14.0 15.0 16.0 18.0 20.0 23.0 25.0 27.0 29.0 29.0 29.0 31.0 
+         8.0 9.0 8.0 11.0 13.0 14.0 15.0 16.0 18.0 19.0 21.0 24.0 27.0 29.0 29.0 30.0 
+         4.0 7.0 5.0 9.0 12.0 13.0 14.0 15.0 16.0 17.0 20.0 23.0 26.0 28.0 28.0 29.0 
+         2.0 3.0 3.0 7.0 10.0 12.0 14.0 14.0 15.0 16.0 17.0 21.0 24.0 26.0 26.0 28.0 
+         1.0 2.0 2.0 6.0 9.0 11.0 13.0 13.0 14.0 15.0 16.0 20.0 23.0 25.0 25.0 27.0 
+         1.0 2.0 2.0 6.0 9.0 11.0 13.0 13.0 14.0 15.0 16.0 20.0 23.0 25.0 25.0 27.0 
+         0.0 1.0 1.0 5.0 8.0 10.0 12.0 12.0 13.0 14.0 15.0 19.0 22.0 24.0 24.0 26.0 
       </constant>
 <constant cols="1" digits="0" name="rpmBins2" rows="16" units="RPM">
          700.0 
          900.0 
          1100.0 
-         1400.0 
+         1300.0 
+         1500.0 
          1700.0 
          2000.0 
          2300.0 
@@ -712,10 +712,10 @@
          4500.0 
          5000.0 
          6000.0 
-         7000.0 
-         7500.0 
+         7200.0 
       </constant>
 <constant cols="1" digits="0" name="mapBins1" rows="16" units="kPa">
+         10.0 
          16.0 
          20.0 
          26.0 
@@ -731,7 +731,6 @@
          110.0 
          120.0 
          130.0 
-         140.0 
       </constant>
 </page>
 <page number="3" size="128">
@@ -764,21 +763,21 @@
 <constant digits="0" name="missingTeeth" units="teeth">2.0</constant>
 <constant digits="0" name="crankRPM" units="rpm">400.0</constant>
 <constant digits="1" name="tpsflood" units="%">80.0</constant>
-<constant digits="0" name="SoftRevLim" units="rpm">7300.0</constant>
-<constant digits="0" name="SoftLimRetard" units="deg">7.0</constant>
+<constant digits="0" name="SoftRevLim" units="rpm">7100.0</constant>
+<constant digits="0" name="SoftLimRetard" units="deg">20.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">5.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">7200.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7200.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
-         10.0 
-         100.0 
-         380.0 
-         480.0 
+         20.0 
+         180.0 
+         460.0 
+         1200.0 
       </constant>
 <constant cols="1" digits="0" name="taeRates" rows="4" units="%">
          8.0 
-         51.0 
-         120.0 
-         231.0 
+         45.0 
+         94.0 
+         115.0 
       </constant>
 <constant cols="1" digits="0" name="wueBins" rows="10" units="C">
          -30.0 
@@ -817,17 +816,17 @@
          6.0 
          10.0 
       </constant>
-<constant digits="0" name="dfcoRPM" units="RPM">1500.0</constant>
+<constant digits="0" name="dfcoRPM" units="RPM">1400.0</constant>
 <constant digits="0" name="dfcoHyster" units="RPM">200.0</constant>
 <constant digits="1" name="dfcoTPSThresh" units="%">1.0</constant>
 <constant name="ignBypassEnable">"Off"</constant>
 <constant name="ignBypassPin">"3"</constant>
 <constant name="ignBypassHiLo">"LOW"</constant>
-<constant digits="0" name="ADCFILTER_TPS" units="%">50.0</constant>
-<constant digits="0" name="ADCFILTER_CLT" units="%">180.0</constant>
-<constant digits="0" name="ADCFILTER_IAT" units="%">180.0</constant>
-<constant digits="0" name="ADCFILTER_O2" units="%">100.0</constant>
-<constant digits="0" name="ADCFILTER_BAT" units="%">128.0</constant>
+<constant digits="0" name="ADCFILTER_TPS" units="%">1.0</constant>
+<constant digits="0" name="ADCFILTER_CLT" units="%">102.0</constant>
+<constant digits="0" name="ADCFILTER_IAT" units="%">106.0</constant>
+<constant digits="0" name="ADCFILTER_O2" units="%">41.0</constant>
+<constant digits="0" name="ADCFILTER_BAT" units="%">101.0</constant>
 <constant digits="0" name="ADCFILTER_MAP" units="%">20.0</constant>
 <constant digits="0" name="ADCFILTER_BARO" units="%">64.0</constant>
 <constant cols="1" digits="0" name="cltAdvBins" rows="6" units="C">
@@ -891,20 +890,40 @@
          -10.0 
          -8.0 
          0.0 
-         2.0 
          4.0 
-         5.0 
+         8.0 
+         10.0 
       </constant>
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">1500.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">93.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
-<constant name="unusedBits4_123">"0"</constant>
+<constant name="inj4CylPairing">"1+4 &amp; 2+3"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
+<constant name="unusedBits4_123">"1"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">13.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">75.0</constant>
 <constant digits="0" name="vvtMinClt" units="C">-40.0</constant>
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 
+         1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 1.4795918 
+         1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 1.4489796 
+         1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 1.4285714 
+         1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 1.3979592 
+         1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 1.377551 
+         1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 1.3673469 
+         1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 1.3571429 
+         1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 1.3367347 
+         1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 
+         1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 1.3265306 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -912,15 +931,15 @@
          14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
-         14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 14.3 
-         13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 13.9 
-         13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 
-         13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 
-         13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 
+         14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 14.5 
+         14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 14.2 
+         14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 14.0 
+         13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 13.7 
          13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 13.5 
          13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 13.4 
          13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 13.3 
          13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 13.1 
+         13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 
          13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 13.0 
       </constant>
 <constant cols="1" digits="0" name="rpmBinsAFR" rows="16" units="RPM">
@@ -978,8 +997,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"Off"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.9183673</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.9387755</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -987,7 +1008,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Simple"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"Yes"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          8.0 
@@ -1037,15 +1058,15 @@
 <constant digits="0" name="lnchRetard" units="deg">-10.0</constant>
 <constant digits="0" name="lnchHardLim" units="rpm">4000.0</constant>
 <constant digits="0" name="lnchFuelAdd" units="%">20.0</constant>
-<constant digits="2" name="idleKP" units="%">2.0</constant>
-<constant digits="2" name="idleKI" units="%">0.0</constant>
-<constant digits="3" name="idleKD" units="%">0.99968</constant>
+<constant digits="2" name="idleKP" units="%">0.03125</constant>
+<constant digits="2" name="idleKI" units="%">0.5</constant>
+<constant digits="3" name="idleKD" units="%">0.00781</constant>
 <constant digits="0" name="boostLimit" units="kPa">200.0</constant>
 <constant digits="0" name="boostKP" units="%">50.0</constant>
 <constant digits="0" name="boostKI" units="%">0.0</constant>
 <constant digits="0" name="boostKD" units="%">10.0</constant>
 <constant name="lnchPullRes">"Pullup"</constant>
-<constant name="iacPWMrun">"No"</constant>
+<constant name="iacPWMrun">"Yes"</constant>
 <constant name="fuelTrimEnabled">"No"</constant>
 <constant name="flatSEnable">"No"</constant>
 <constant name="baroPin">"A5"</constant>
@@ -1060,9 +1081,9 @@
          1000.0 
          1000.0 
          1000.0 
-         1000.0 
-         950.0 
-         900.0 
+         930.0 
+         870.0 
+         800.0 
       </constant>
 <constant cols="1" digits="0" name="iacOLStepVal" rows="10" units="Steps">
          369.0 
@@ -1077,21 +1098,21 @@
          0.0 
       </constant>
 <constant cols="1" digits="0" name="iacOLPWMVal" rows="10" units="Duty %">
-         47.0 
-         45.0 
+         46.0 
+         46.0 
+         44.0 
+         44.0 
          43.0 
-         41.0 
+         43.0 
+         42.0 
          40.0 
-         39.0 
          36.0 
-         35.0 
-         33.0 
-         33.0 
+         34.0 
       </constant>
 <constant cols="1" digits="0" name="iacBins" rows="10" units="C">
          -30.0 
-         -20.0 
-         -10.0 
+         -21.0 
+         -11.0 
          -3.0 
          5.0 
          15.0 
@@ -1133,9 +1154,9 @@
 <constant digits="0" name="fanFreq" units="Hz">6.0</constant>
 <constant cols="1" digits="0" name="fanPWMBins" rows="4" units="C">
          60.0 
-         -20.0 
-         -40.0 
-         158.0 
+         80.0 
+         100.0 
+         120.0 
       </constant>
 </page>
 <page number="6" size="240">
@@ -1170,14 +1191,14 @@
          100.0 
       </constant>
 <constant cols="8" digits="1" name="vvtTable" rows="8" units="%">
-         40.0 40.0 40.0 38.0 36.0 29.0 28.0 28.0 
-         40.0 40.0 40.0 38.0 37.0 30.0 30.0 30.0 
-         40.0 40.0 40.0 31.0 30.0 30.0 31.0 31.0 
-         40.0 34.0 34.0 22.0 24.0 29.0 32.0 33.0 
-         40.0 30.0 32.0 14.0 17.0 28.0 33.0 34.0 
-         40.0 27.0 29.0 5.0 10.0 28.0 34.0 36.0 
-         40.0 17.0 22.0 5.0 10.0 27.0 35.0 37.0 
-         40.0 17.0 20.0 5.0 10.0 25.0 37.0 40.0 
+         40.5 40.0 40.0 38.0 36.0 29.0 28.0 28.0 
+         40.5 40.0 40.0 38.0 37.0 30.0 30.0 30.5 
+         40.5 40.0 40.0 31.0 30.0 30.0 31.0 33.0 
+         40.5 34.0 34.0 22.0 24.0 29.0 32.0 35.5 
+         40.5 30.0 32.0 14.0 17.0 28.0 33.0 37.5 
+         40.5 27.0 29.0 5.0 10.0 28.0 34.0 40.0 
+         40.5 17.0 22.0 5.0 10.0 27.0 35.0 42.5 
+         40.5 17.0 20.0 5.0 10.0 25.0 37.0 45.0 
       </constant>
 <constant cols="1" digits="0" name="rpmBinsVVT" rows="8" units="RPM">
          700.0 
@@ -1187,17 +1208,17 @@
          3000.0 
          4000.0 
          5000.0 
-         6500.0 
+         6000.0 
       </constant>
 <constant cols="1" digits="0" name="loadBinsVVT" rows="8" units="kPa">
-         20.0 
          30.0 
          40.0 
          50.0 
          60.0 
          70.0 
          80.0 
-         100.0 
+         88.0 
+         96.0 
       </constant>
 <constant cols="8" digits="0" name="stagingTable" rows="8" units="%">
          0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 
@@ -1427,34 +1448,34 @@
 <page number="8" size="192">
 <constant name="enable_secondarySerial">"Enable"</constant>
 <constant name="intcan_available">"Disable"</constant>
-<constant name="enable_intcan">"Disable"</constant>
+<constant name="enable_intcan">"Enable"</constant>
 <constant name="caninput_sel0a">"Off"</constant>
 <constant name="caninput_sel0b">"Analog_local"</constant>
 <constant name="caninput_sel0extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel0extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel0extsourcec">"Via Internal CAN"</constant>
 <constant name="caninput_sel1a">"Off"</constant>
-<constant name="caninput_sel1b">"Off"</constant>
+<constant name="caninput_sel1b">"Analog_local"</constant>
 <constant name="caninput_sel1extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel1extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel1extsourcec">"Via Internal CAN"</constant>
 <constant name="caninput_sel2a">"Off"</constant>
-<constant name="caninput_sel2b">"External Source"</constant>
+<constant name="caninput_sel2b">"Off"</constant>
 <constant name="caninput_sel2extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel2extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel2extsourcec">"Via Internal CAN"</constant>
 <constant name="caninput_sel3a">"Off"</constant>
-<constant name="caninput_sel3b">"External Source"</constant>
+<constant name="caninput_sel3b">"Off"</constant>
 <constant name="caninput_sel3extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel3extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel3extsourcec">"Via Internal CAN"</constant>
 <constant name="caninput_sel4a">"Off"</constant>
-<constant name="caninput_sel4b">"External Source"</constant>
+<constant name="caninput_sel4b">"Off"</constant>
 <constant name="caninput_sel4extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel4extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel4extsourcec">"Via Internal CAN"</constant>
 <constant name="caninput_sel5a">"Off"</constant>
-<constant name="caninput_sel5b">"External Source"</constant>
+<constant name="caninput_sel5b">"Off"</constant>
 <constant name="caninput_sel5extsourcea">"Via Secondary Serial"</constant>
 <constant name="caninput_sel5extsourceb">"Via Internal CAN"</constant>
 <constant name="caninput_sel5extsourcec">"Via Internal CAN"</constant>
@@ -1556,7 +1577,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">255.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">255.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1602,7 +1623,7 @@
 <constant name="realtime_base_address">"0x201"</constant>
 <constant name="obd_address">"0x2FF"</constant>
 <constant name="Auxin0pina">"A13"</constant>
-<constant name="Auxin1pina">"A0"</constant>
+<constant name="Auxin1pina">"A14"</constant>
 <constant name="Auxin2pina">"A0"</constant>
 <constant name="Auxin3pina">"A0"</constant>
 <constant name="Auxin4pina">"A0"</constant>
@@ -1637,7 +1658,7 @@
 <constant name="iacCoolTime">"0"</constant>
 <constant name="boostByGearEnabled">"Off"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">21.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1">14.0</constant>
@@ -1647,39 +1668,44 @@
 <constant digits="0" name="boostByGear5">14.0</constant>
 <constant digits="0" name="boostByGear6">14.0</constant>
 <constant cols="1" digits="1" name="PWMFanDuty" rows="4" units="%">
-         0.0 
          10.0 
-         13.5 
+         10.0 
+         20.0 
+         90.0 
+      </constant>
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         3000.0 
+         4000.0 
+         4500.0 
+         5000.0 
+         6000.0 
+         7000.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -30.0 
+         -10.0 
+         0.0 
+         20.0 
          40.0 
+         100.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
          7.0 
          7.0 
          7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         69.0 
-         16.0 
-         9.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.1428571</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.0</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">4.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1777,6 +1803,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">250.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">30.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">18.0</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.8367347</constant>
 <constant name="n2o_stage1_pin">"30"</constant>
 <constant name="n2o_pin_polarity">"LOW"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1835,8 +1862,8 @@
 <constant digits="0" name="knock_recoveryStep" units="Deg">0.0</constant>
 <constant name="fuel2Algorithm">"MAP"</constant>
 <constant name="fuel2Mode">"Off"</constant>
-<constant name="fuel2SwitchVariable">"MAP"</constant>
-<constant digits="0" name="fuel2SwitchValue" units="kPa">200.0</constant>
+<constant name="fuel2SwitchVariable">"ETH%"</constant>
+<constant digits="0" name="fuel2SwitchValue" units="%">65535.0</constant>
 <constant name="fuel2InputPin">"3"</constant>
 <constant name="fuel2InputPolarity">"HIGH"</constant>
 <constant name="fuel2InputPullup">"Yes"</constant>
@@ -1857,13 +1884,13 @@
 <constant digits="0" name="fuelPressureMax" units="psi">171.0</constant>
 <constant digits="0" name="oilPressureMin" units="psi">0.0</constant>
 <constant digits="0" name="oilPressureMax" units="psi">0.0</constant>
-<constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
+<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
          0.0 
          0.0 
          0.0 
          0.0 
       </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
+<constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
          0.0 
          0.0 
          0.0 
@@ -1929,8 +1956,8 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         0.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
          0.0 
       </constant>
 </page>
@@ -2042,9 +2069,9 @@
          7000.0 
       </constant>
 <constant cols="1" digits="0" name="loadBinsVVT2" rows="8" units="kPa">
-         20.0 
          30.0 
          40.0 
+         50.0 
          60.0 
          70.0 
          80.0 
@@ -2063,7 +2090,7 @@
          10200.0 
          10200.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
          206.0 
          206.0 
          206.0 
@@ -2098,8 +2125,8 @@
 <constant name="kindOfLimiting6">"Maximum"</constant>
 <constant name="kindOfLimiting7">"Minimum"</constant>
 <constant cols="1" digits="0" name="outputPin" rows="8">
-         37.0 
          35.0 
+         40.0 
          0.0 
          0.0 
          0.0 
@@ -2128,21 +2155,21 @@
 <constant cols="1" digits="0" name="firstDataIn" rows="8">
          14.0 
          7.0 
-         108.0 
-         108.0 
-         108.0 
          109.0 
          109.0 
          109.0 
+         110.0 
+         110.0 
+         110.0 
       </constant>
 <constant name="firstDataIn0">"RPM"</constant>
 <constant name="firstDataIn1">"coolant"</constant>
-<constant name="firstDataIn2">"WMI empty"</constant>
-<constant name="firstDataIn3">"WMI empty"</constant>
-<constant name="firstDataIn4">"WMI empty"</constant>
-<constant name="firstDataIn5">"VVT2 angle"</constant>
-<constant name="firstDataIn6">"VVT2 angle"</constant>
-<constant name="firstDataIn7">"VVT2 angle"</constant>
+<constant name="firstDataIn2">"WMI duty"</constant>
+<constant name="firstDataIn3">"WMI duty"</constant>
+<constant name="firstDataIn4">"WMI duty"</constant>
+<constant name="firstDataIn5">"WMI empty"</constant>
+<constant name="firstDataIn6">"WMI empty"</constant>
+<constant name="firstDataIn7">"WMI empty"</constant>
 <constant cols="1" digits="0" name="secondDataIn" rows="8">
          4.0 
          4.0 
@@ -2155,12 +2182,11 @@
       </constant>
 <constant name="secondDataIn0">"MAP (Kpa)"</constant>
 <constant name="secondDataIn1">"MAP (Kpa)"</constant>
-<constant name="secondDataIn2">"VVT2 target"</constant>
-<constant name="secondDataIn3">"VVT2 target"</constant>
-<constant name="secondDataIn4">"VVT2 target"</constant>
-<constant name="secondDataIn5">"VVT2 target"</constant>
-<constant name="secondDataIn6">"VVT2 target"</constant>
-<constant name="secondDataIn7">"VVT2 duty"</constant>
+<constant name="secondDataIn2">"VVT2 angle"</constant>
+<constant name="secondDataIn3">"VVT2 angle"</constant>
+<constant name="secondDataIn4">"VVT2 angle"</constant>
+<constant name="secondDataIn5">"VVT2 angle"</constant>
+<constant name="secondDataIn6">"VVT2 angle"</constant>
 <constant cols="1" digits="1" name="outputTimeLimit" rows="8" units="S">
          0.0 
          0.0 
@@ -2182,7 +2208,7 @@
          114.0 
       </constant>
 <constant cols="1" digits="0" name="firstTarget" rows="8">
-         4000.0 
+         4300.0 
          95.0 
          29555.0 
          29555.0 
@@ -2201,8 +2227,8 @@
          30839.0 
          30840.0 
       </constant>
-<constant name="firstCompType0">"&gt;= (greater/equal)"</constant>
-<constant name="secondCompType0">"&gt;= (greater/equal)"</constant>
+<constant name="firstCompType0">"&lt; (smaller)"</constant>
+<constant name="secondCompType0">"&gt; (greater)"</constant>
 <constant name="bitwise0">"AND"</constant>
 <constant name="firstCompType1">"&gt;= (greater/equal)"</constant>
 <constant name="secondCompType1">"&gt;= (greater/equal)"</constant>
@@ -2236,40 +2262,40 @@
          32124.0 
       </constant>
 <constant cols="1" digits="0" name="unused12_106_115" rows="10" units="%">
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
-         255.0 
+         125.0 
+         125.0 
+         125.0 
+         125.0 
+         126.0 
+         126.0 
+         126.0 
+         126.0 
+         126.0 
+         127.0 
       </constant>
-<constant name="onboard_log_csv_separator">"space"</constant>
+<constant name="onboard_log_csv_separator">";"</constant>
 <constant name="onboard_log_file_style">"Disabled"</constant>
-<constant name="onboard_log_file_rate">"30Hz"</constant>
+<constant name="onboard_log_file_rate">"1Hz"</constant>
 <constant name="onboard_log_filenaming">"Overwrite"</constant>
 <constant name="onboard_log_storage">"sd-card"</constant>
-<constant name="onboard_log_trigger_boot">"On boot"</constant>
-<constant name="onboard_log_trigger_RPM">"Enabled"</constant>
-<constant name="onboard_log_trigger_prot">"Enabled"</constant>
-<constant name="onboard_log_trigger_Vbat">"Enabled"</constant>
+<constant name="onboard_log_trigger_boot">"Disabled"</constant>
+<constant name="onboard_log_trigger_RPM">"Disabled"</constant>
+<constant name="onboard_log_trigger_prot">"Disabled"</constant>
+<constant name="onboard_log_trigger_Vbat">"Disabled"</constant>
 <constant name="onboard_log_trigger_Epin">"Disabled"</constant>
-<constant digits="0" name="onboard_log_tr1_duration" units="s">65535.0</constant>
-<constant digits="0" name="onboard_log_tr2_thr_on" units="RPM">25500.0</constant>
-<constant digits="0" name="onboard_log_tr2_thr_off" units="RPM">25500.0</constant>
-<constant name="onboard_log_tr3_thr_RPM">"Enabled"</constant>
-<constant name="onboard_log_tr3_thr_MAP">"Enabled"</constant>
-<constant name="onboard_log_tr3_thr_Oil">"Enabled"</constant>
-<constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
-<constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
-<constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant digits="0" name="onboard_log_tr1_duration" units="s">0.0</constant>
+<constant digits="0" name="onboard_log_tr2_thr_on" units="RPM">0.0</constant>
+<constant digits="0" name="onboard_log_tr2_thr_off" units="RPM">0.0</constant>
+<constant name="onboard_log_tr3_thr_RPM">"Disabled"</constant>
+<constant name="onboard_log_tr3_thr_MAP">"Disabled"</constant>
+<constant name="onboard_log_tr3_thr_Oil">"Disabled"</constant>
+<constant name="onboard_log_tr3_thr_AFR">"Disabled"</constant>
+<constant digits="2" name="onboard_log_tr4_thr_on" units="V">0.0</constant>
+<constant digits="2" name="onboard_log_tr4_thr_off" units="V">0.0</constant>
+<constant name="unused13_125_2">"tab"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
-         255.0 
-         255.0 
+         129.0 
+         129.0 
       </constant>
 </page>
 <page number="13" size="288">
@@ -2292,44 +2318,265 @@
          -7.0 -6.0 0.0 2.0 4.0 7.0 9.0 10.0 11.0 13.0 15.0 17.0 19.0 20.0 21.0 21.0 
       </constant>
 <constant cols="1" digits="0" name="rpmBins3" rows="16" units="RPM">
-         700.0 
-         900.0 
-         1100.0 
-         1400.0 
-         1700.0 
+         18000.0 
+         18000.0 
+         18000.0 
+         18000.0 
+         18000.0 
+         18100.0 
+         18100.0 
+         18100.0 
+         18100.0 
+         18100.0 
+         18200.0 
+         18200.0 
+         18200.0 
+         18200.0 
+         18200.0 
+         18300.0 
+      </constant>
+<constant cols="1" digits="1" name="mapBins2" rows="16" units="% TPS">
+         116.0 
+         114.0 
+         114.0 
+         114.0 
+         114.0 
+         114.0 
+         112.0 
+         112.0 
+         112.0 
+         112.0 
+         112.0 
+         110.0 
+         110.0 
+         110.0 
+         110.0 
+         110.0 
+      </constant>
+</page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
          2000.0 
-         2300.0 
-         2600.0 
+         2500.0 
          3000.0 
          3500.0 
          4000.0 
          4500.0 
          5000.0 
-         6000.0 
-         7000.0 
-         7500.0 
       </constant>
-<constant cols="1" digits="1" name="mapBins2" rows="16" units="% TPS">
-         16.0 
-         20.0 
-         26.0 
-         30.0 
-         36.0 
-         40.0 
-         50.0 
-         60.0 
-         70.0 
-         80.0 
-         90.0 
-         100.0 
-         100.0 
-         100.0 
-         100.0 
-         100.0 
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Enabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">127.5</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">2550.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">25500.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">215.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">255.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">25.5</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">25.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">25.5</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">25.5</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">2550.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">127.5</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
       </constant>
 </page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>

--- a/BMW/M52_PnP.msq
+++ b/BMW/M52_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 10:31:06 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+2023.05" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">5500.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">6500.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -21,6 +24,18 @@
          -0.2 
          -0.1 
          0.0 
+      </pcVariable>
+<pcVariable cols="1" digits="0" name="wueRecommended" rows="10" units="%">
+         144.0 
+         144.0 
+         143.0 
+         140.0 
+         132.0 
+         124.0 
+         118.0 
+         111.0 
+         105.0 
+         100.0 
       </pcVariable>
 <pcVariable cols="1" digits="0" name="boardFuelOutputs" rows="128" units=" ">
          4.0 
@@ -422,6 +437,7 @@
          100.0 
          100.0 
       </pcVariable>
+<pcVariable name="prgm_out_selection">"2"</pcVariable>
 <pcVariable digits="0" name="fuelLoadMax">255.0</pcVariable>
 <pcVariable digits="0" name="ignLoadMax">255.0</pcVariable>
 <pcVariable digits="0" name="fuel2LoadMax">255.0</pcVariable>
@@ -456,19 +472,15 @@
 <constant digits="0" name="tachoDuration" units="ms">1.0</constant>
 <constant digits="0" name="maeThresh" units="kPa/s">255.0</constant>
 <constant digits="0" name="taeThresh" units="%/s">20.0</constant>
-<constant digits="0" name="aeTime" units="ms">20.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="0" name="aeTime" units="ms">40.0</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">16.5</constant>
 <constant digits="0" name="divider">3.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"Yes"</constant>
+<constant name="crkngAddCLTAdv">"Yes"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
@@ -501,8 +513,8 @@
 <constant digits="0" name="boostMaxDuty" units="%">80.0</constant>
 <constant digits="0" name="tpsMin" units="ADC">32.0</constant>
 <constant digits="0" name="tpsMax" units="ADC">197.0</constant>
-<constant digits="0" name="mapMin" units="kpa">10.0</constant>
-<constant digits="0" name="mapMax" units="kpa">260.0</constant>
+<constant digits="0" name="mapMin" units="kpa">3.0</constant>
+<constant digits="0" name="mapMax" units="kpa">416.0</constant>
 <constant digits="0" name="fpPrime" units="s">2.0</constant>
 <constant digits="1" name="stoich" units=":1">14.7</constant>
 <constant digits="0" name="oddfire2" units="deg">0.0</constant>
@@ -514,11 +526,11 @@
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
 <constant digits="0" name="aeTaperMax" units="RPM">5000.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">0.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">0.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">0.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">0.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">10.0</constant>
-<constant digits="0" name="baroMax" units="kpa">118.0</constant>
+<constant digits="0" name="baroMax" units="kpa">121.0</constant>
 <constant digits="0" name="EMAPMin" units="kpa">10.0</constant>
 <constant digits="0" name="EMAPMax" units="kpa">118.0</constant>
 <constant name="fanWhenOff">"Yes"</constant>
@@ -576,7 +588,7 @@
 <constant digits="0" name="dfcoMinCLT" units="C">30.0</constant>
 <constant name="vssMode">"Off"</constant>
 <constant name="vssPin">"3"</constant>
-<constant digits="0" name="vssPulsesPerKm" units="pulses">11.0</constant>
+<constant digits="0" name="vssPulsesPerKm" units="pulses">0.0</constant>
 <constant digits="0" name="vssSmoothing" units="%">20.0</constant>
 <constant digits="1" name="vssRatio1" units="km/h per 1000rpm">0.0</constant>
 <constant digits="1" name="vssRatio2" units="km/h per 1000rpm">0.0</constant>
@@ -588,16 +600,18 @@
 <constant name="idleUpOutputInv">"No"</constant>
 <constant name="idleUpOutputPin">"Board Default"</constant>
 <constant digits="0" name="tachoSweepMaxRPM" units="RPM">1800.0</constant>
-<constant digits="1" name="primingDelay" units="S">0.5</constant>
+<constant digits="1" name="primingDelay" units="S">0.8</constant>
 <constant digits="1" name="iacTPSlimit" units="%">0.0</constant>
 <constant digits="0" name="iacRPMlimitHysteresis" units="RPM">600.0</constant>
 <constant digits="0" name="rtc_trim" units="ppm">0.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">0.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1400.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
@@ -736,7 +750,7 @@
 <constant name="TrigFilter">"Weak"</constant>
 <constant name="ignCranklock">"Off"</constant>
 <constant digits="1" name="dwellcrank" units="ms">6.0</constant>
-<constant digits="1" name="dwellrun" units="ms">1.5</constant>
+<constant digits="1" name="dwellrun" units="ms">2.0</constant>
 <constant digits="0" name="numTeeth" units="teeth">60.0</constant>
 <constant digits="0" name="missingTeeth" units="teeth">2.0</constant>
 <constant digits="0" name="crankRPM" units="rpm">400.0</constant>
@@ -744,7 +758,7 @@
 <constant digits="0" name="SoftRevLim" units="rpm">6500.0</constant>
 <constant digits="0" name="SoftLimRetard" units="deg">10.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">2.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">7000.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7200.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
          10.0 
          260.0 
@@ -875,6 +889,8 @@
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">1600.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">0.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
+<constant name="inj4CylPairing">"1+4 &amp; 2+3"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
 <constant name="unusedBits4_123">"0"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">4.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">0.0</constant>
@@ -882,6 +898,24 @@
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0136054 1.0204082 1.0204082 1.0068027 1.0 1.0 1.0 0.9931973 0.9863946 0.9863946 0.9795918 0.9795918 
+         1.0 1.0 1.0 1.0 1.0068027 1.0136054 1.0136054 1.0 0.9931973 0.9863946 0.9795918 0.9727891 0.9659864 0.952381 0.952381 0.952381 
+         0.9863946 0.9863946 0.9863946 0.9863946 0.9931973 1.0 1.0 0.9863946 0.9795918 0.9727891 0.9727891 0.9659864 0.9591837 0.9455782 0.9455782 0.9455782 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9795918 0.9795918 0.9795918 0.9727891 0.9659864 0.9659864 0.9591837 0.952381 0.952381 0.9387755 0.9387755 0.9387755 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9659864 0.9659864 0.9659864 0.9591837 0.9591837 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 
+         0.9455782 0.9455782 0.9455782 0.9455782 0.9455782 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 0.9319728 0.9319728 0.9319728 0.9319728 
+         0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 
+         0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 
+         0.8979592 0.8979592 0.8979592 0.8979592 0.8979592 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 
+         0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.877551 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -955,8 +989,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"On"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.6122449</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.292517</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -964,7 +1000,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Full"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"No"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          8.0 
@@ -1533,7 +1569,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">255.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">255.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1614,7 +1650,7 @@
 <constant name="iacCoolTime">"0"</constant>
 <constant name="boostByGearEnabled">"Constant limit"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">21.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1" units="Limit">0.0</constant>
@@ -1629,27 +1665,24 @@
          13.5 
          40.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
-         0.0 
-         21.0 
-         44.0 
-         45.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+      </constant>
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
@@ -1657,6 +1690,14 @@
          7.0 
          7.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.0952381</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.0</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">4.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1754,6 +1795,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">250.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">30.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">18.0</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.2244898</constant>
 <constant name="n2o_stage1_pin">"30"</constant>
 <constant name="n2o_pin_polarity">"LOW"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1830,21 +1872,21 @@
 <constant name="oilPressureProtEnbl">"Off"</constant>
 <constant name="oilPressurePin">"A12"</constant>
 <constant name="fuelPressurePin">"A5"</constant>
-<constant digits="0" name="fuelPressureMin" units="psi">52.0</constant>
-<constant digits="0" name="fuelPressureMax" units="psi">158.0</constant>
-<constant digits="0" name="oilPressureMin" units="psi">-66.0</constant>
-<constant digits="0" name="oilPressureMax" units="psi">62.0</constant>
+<constant digits="2" name="fuelPressureMin" units="BAR">-1.6054</constant>
+<constant digits="2" name="fuelPressureMax" units="BAR">15.0768</constant>
+<constant digits="2" name="oilPressureMin" units="BAR">5.4444</constant>
+<constant digits="2" name="oilPressureMax" units="BAR">8.376</constant>
+<constant cols="1" digits="2" name="oilPressureProtMins" rows="4" units="BAR">
+         6.98 
+         14.0298 
+         7.2592 
+         9.2834 
+      </constant>
 <constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
          800.0 
          2000.0 
          4000.0 
          7000.0 
-      </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
-         7.0 
-         14.0 
-         43.0 
-         45.0 
       </constant>
 <constant name="wmiEnabled">"Off"</constant>
 <constant name="wmiMode">"Openloop"</constant>
@@ -1906,9 +1948,9 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         1500.0 
-         500.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
+         0.0 
       </constant>
 </page>
 <page number="10" size="288">
@@ -2040,11 +2082,11 @@
          3000.0 
          4000.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
-         10.0 
-         50.0 
-         100.0 
-         200.0 
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
+         206.0 
+         206.0 
+         206.0 
+         204.0 
       </constant>
 <constant cols="1" digits="0" name="UNALLOCATED_TOP_11" rows="8" units="RAW">
          0.0 
@@ -2228,7 +2270,7 @@
 <constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
 <constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
 <constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant name="unused13_125_2">"tab"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
          255.0 
          255.0 
@@ -2290,8 +2332,230 @@
          240.0 
       </constant>
 </page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
+         2000.0 
+         2500.0 
+         3000.0 
+         3500.0 
+         4000.0 
+         4500.0 
+         5000.0 
+      </constant>
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Disabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">50.0</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">600.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">4000.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">110.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">5.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">2.0</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">0.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">5.0</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">2.0</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">100.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">40.0</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+      </constant>
+</page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
+<setting name="pressure_bar" value="pressure_bar"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>

--- a/BMW/M60_PnP.msq
+++ b/BMW/M60_PnP.msq
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <msq xmlns="http://www.msefi.com/:msq">
-<bibliography author="TunerStudio MS Lite! 3.1.06 - EFI Analytics, Inc." tuneComment="" writeDate="Wed Jan 12 11:30:19 EET 2022"/>
-<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="14" signature="speeduino 202202"/>
+<bibliography author="TunerStudio MS Lite! 3.1.08 - EFI Analytics, Inc." tuneComment="" writeDate="Thu Apr 18 10:54:24 EEST 2024"/>
+<versionInfo fileFormat="5.0" firmwareInfo="Speeduino+202202" nPages="15" signature="speeduino 202305"/>
 <page>
 <pcVariable name="tsCanId">"0"</pcVariable>
+<pcVariable name="tsCanId">"CAN ID 0"</pcVariable>
 <pcVariable digits="0" name="rpmhigh" units="rpm">8000.0</pcVariable>
 <pcVariable digits="0" name="rpmwarn" units="rpm">5500.0</pcVariable>
 <pcVariable digits="0" name="rpmdang" units="rpm">6500.0</pcVariable>
 <pcVariable digits="0" name="maphigh" units="kPa">255.0</pcVariable>
 <pcVariable digits="0" name="mapwarn" units="kPa">200.0</pcVariable>
 <pcVariable digits="0" name="mapdang" units="kPa">245.0</pcVariable>
+<pcVariable digits="1" name="batlow" units="Volts">11.8</pcVariable>
+<pcVariable digits="1" name="bathigh" units="Volts">15.0</pcVariable>
 <pcVariable cols="1" digits="1" name="wueAFR" rows="10" units="AFR">
          -2.0 
          -1.5 
@@ -470,18 +473,14 @@
 <constant digits="0" name="maeThresh" units="kPa/s">255.0</constant>
 <constant digits="0" name="taeThresh" units="%/s">20.0</constant>
 <constant digits="0" name="aeTime" units="ms">20.0</constant>
-<constant name="display">"Unused"</constant>
-<constant name="display1">"VE"</constant>
-<constant name="display2">"CPU"</constant>
-<constant name="display3">"TPS"</constant>
-<constant name="display4">"Mem"</constant>
-<constant name="display5">"RPM"</constant>
+<constant digits="1" name="taeMinChange" units="%">0.5</constant>
+<constant digits="0" name="maeMinChange" units="kPa">2.0</constant>
 <constant name="displayB1">"RPM"</constant>
 <constant name="displayB2">"RPM"</constant>
 <constant digits="1" name="reqFuel" units="ms">16.8</constant>
 <constant digits="0" name="divider">4.0</constant>
 <constant name="alternate">"Alternating"</constant>
-<constant name="multiplyMAP1">"Yes"</constant>
+<constant name="crkngAddCLTAdv">"Yes"</constant>
 <constant name="includeAFR">"No"</constant>
 <constant name="hardCutType">"Full"</constant>
 <constant name="ignAlgorithm">"MAP"</constant>
@@ -527,8 +526,8 @@
 <constant digits="0" name="idleUpAdder" units="% / Steps">163.0</constant>
 <constant digits="0" name="aeTaperMin" units="RPM">1000.0</constant>
 <constant digits="0" name="aeTaperMax" units="RPM">5000.0</constant>
-<constant digits="0" name="iacCLminDuty" units="%">0.0</constant>
-<constant digits="0" name="iacCLmaxDuty" units="%">0.0</constant>
+<constant digits="0" name="iacCLminValue" units="% / Steps">0.0</constant>
+<constant digits="0" name="iacCLmaxValue" units="% / Steps">0.0</constant>
 <constant digits="0" name="boostMinDuty" units="%">20.0</constant>
 <constant digits="0" name="baroMin" units="kpa">10.0</constant>
 <constant digits="0" name="baroMax" units="kpa">118.0</constant>
@@ -589,7 +588,7 @@
 <constant digits="0" name="dfcoMinCLT" units="C">0.0</constant>
 <constant name="vssMode">"Off"</constant>
 <constant name="vssPin">"Board Default"</constant>
-<constant digits="0" name="vssPulsesPerKm" units="pulses">11.0</constant>
+<constant digits="0" name="vssPulsesPerKm" units="pulses">0.0</constant>
 <constant digits="0" name="vssSmoothing" units="%">255.0</constant>
 <constant digits="1" name="vssRatio1" units="km/h per 1000rpm">0.0</constant>
 <constant digits="1" name="vssRatio2" units="km/h per 1000rpm">0.0</constant>
@@ -607,10 +606,12 @@
 <constant digits="0" name="rtc_trim" units="ppm">0.0</constant>
 <constant digits="0" name="idleAdvVss" units="km/h">0.0</constant>
 <constant digits="0" name="mapSwitchPoint" units="RPM">1400.0</constant>
-<constant cols="1" digits="0" name="unused2_95" rows="2" units="%">
-         255.0 
-         255.0 
-      </constant>
+<constant name="canBMWCluster">"Off"</constant>
+<constant name="canVAGCluster">"Off"</constant>
+<constant name="enable1Cluster">"Off"</constant>
+<constant name="enable2Cluster">"Off"</constant>
+<constant name="vssAuxCh">"Aux0"</constant>
+<constant digits="0" name="decelAmount" units="%">95.0</constant>
 </page>
 <page number="1" size="288">
 <constant cols="16" digits="0" name="veTable" rows="16" units="%">
@@ -757,7 +758,7 @@
 <constant digits="0" name="SoftRevLim" units="rpm">6500.0</constant>
 <constant digits="0" name="SoftLimRetard" units="deg">7.0</constant>
 <constant digits="1" name="SoftLimMax" units="s">2.0</constant>
-<constant digits="0" name="HardRevLim" units="rpm">7000.0</constant>
+<constant digits="0" name="hardRevLim" units="rpm">7000.0</constant>
 <constant cols="1" digits="0" name="taeBins" rows="4" units="%/s">
          10.0 
          260.0 
@@ -888,6 +889,8 @@
 <constant digits="0" name="engineProtectMaxRPM" units="rpm">1600.0</constant>
 <constant digits="0" name="vvt2CL0DutyAng" units="deg">0.0</constant>
 <constant name="vvt2PWMdir">"Advance"</constant>
+<constant name="inj4CylPairing">"1+3 &amp; 2+4"</constant>
+<constant name="dwellErrCorrect">"Off"</constant>
 <constant name="unusedBits4_123">"0"</constant>
 <constant digits="0" name="ANGLEFILTER_VVT" units="%">4.0</constant>
 <constant digits="0" name="FILTER_FLEX" units="%">0.0</constant>
@@ -895,6 +898,24 @@
 <constant digits="0" name="vvtDelay" units="S">0.0</constant>
 </page>
 <page number="4" size="288">
+<constant cols="16" digits="3" name="lambdaTable" rows="16" units="Lambda">
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0204082 1.0272109 1.0272109 1.0068027 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 
+         1.0 1.0 1.0 1.0 1.0136054 1.0204082 1.0204082 1.0068027 1.0 1.0 1.0 0.9931973 0.9863946 0.9863946 0.9795918 0.9795918 
+         1.0 1.0 1.0 1.0 1.0068027 1.0136054 1.0136054 1.0 0.9931973 0.9863946 0.9795918 0.9727891 0.9659864 0.952381 0.952381 0.952381 
+         0.9863946 0.9863946 0.9863946 0.9863946 0.9931973 1.0 1.0 0.9863946 0.9795918 0.9727891 0.9727891 0.9659864 0.9591837 0.9455782 0.9455782 0.9455782 
+         0.9727891 0.9727891 0.9727891 0.9727891 0.9795918 0.9795918 0.9795918 0.9727891 0.9659864 0.9659864 0.9591837 0.952381 0.952381 0.9387755 0.9387755 0.9387755 
+         0.9591837 0.9591837 0.9591837 0.9591837 0.9659864 0.9659864 0.9659864 0.9591837 0.9591837 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 
+         0.9455782 0.9455782 0.9455782 0.9455782 0.9455782 0.952381 0.952381 0.9455782 0.9455782 0.9387755 0.9387755 0.9387755 0.9319728 0.9319728 0.9319728 0.9319728 
+         0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 0.9183673 
+         0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 0.9047619 
+         0.8979592 0.8979592 0.8979592 0.8979592 0.8979592 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 0.8911565 
+         0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.8843537 0.877551 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+         0.8707483 0.8707483 0.8707483 0.8707483 0.8707483 0.8639456 0.8571429 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 0.8503401 
+      </constant>
 <constant cols="16" digits="1" name="afrTable" rows="16" units="AFR">
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
          14.7 14.7 14.7 14.7 15.0 15.1 15.1 14.8 14.7 14.7 14.7 14.7 14.7 14.7 14.7 14.7 
@@ -968,8 +989,10 @@
 <constant name="vvtCLAlterFuelTiming">"No"</constant>
 <constant name="boostCutEnabled">"On"</constant>
 <constant digits="0" name="egoLimit">15.0</constant>
-<constant digits="1" name="ego_min" units="AFR">9.0</constant>
-<constant digits="1" name="ego_max" units="AFR">19.0</constant>
+<constant digits="1" name="ego_min_afr" units="AFR">9.0</constant>
+<constant digits="3" name="ego_min_lambda" units="Lambda">0.6122449</constant>
+<constant digits="1" name="ego_max_afr" units="AFR">19.0</constant>
+<constant digits="3" name="ego_max_lambda" units="Lambda">1.292517</constant>
 <constant digits="0" name="ego_sdelay" units="sec">15.0</constant>
 <constant digits="0" name="egoRPM" units="rpm">1200.0</constant>
 <constant digits="1" name="egoTPSMax" units="%">70.0</constant>
@@ -977,7 +1000,7 @@
 <constant name="useExtBaro">"No"</constant>
 <constant name="boostMode">"Simple"</constant>
 <constant name="boostPin">"Board Default"</constant>
-<constant name="unused_bit">"No"</constant>
+<constant name="tachoMode">"Match Dwell"</constant>
 <constant name="useEMAP">"No"</constant>
 <constant cols="1" digits="1" name="brvBins" rows="6" units="V">
          8.0 
@@ -1546,7 +1569,7 @@
 <constant name="caninput_source_num_bytes13">"2"</constant>
 <constant name="caninput_source_num_bytes14">"2"</constant>
 <constant name="caninput_source_num_bytes15">"2"</constant>
-<constant digits="0" name="unused10_67">255.0</constant>
+<constant name="caninputEndianess">"Little-Endian"</constant>
 <constant digits="0" name="unused10_68">255.0</constant>
 <constant name="enable_intcandata_out">"On"</constant>
 <constant name="canoutput_sel0">"On"</constant>
@@ -1627,7 +1650,7 @@
 <constant name="iacCoolTime">"0"</constant>
 <constant name="boostByGearEnabled">"Constant limit"</constant>
 <constant name="blankfield">""</constant>
-<constant name="unused10_153">""</constant>
+<constant name="iacStepperPower">"When Active"</constant>
 <constant digits="0" name="iacMaxSteps" units="Steps">21.0</constant>
 <constant digits="1" name="idleAdvStartDelay" units="S">0.2</constant>
 <constant digits="0" name="boostByGear1" units="Limit">0.0</constant>
@@ -1642,27 +1665,24 @@
          13.5 
          40.0 
       </constant>
-<constant cols="1" digits="0" name="unused10_160" rows="26">
-         0.0 
-         21.0 
-         44.0 
-         45.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
-         7.0 
+<constant name="hardRevMode">"Fixed"</constant>
+<constant cols="1" digits="0" name="coolantProtRPM" rows="6" units="RPM">
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+         700.0 
+      </constant>
+<constant cols="1" digits="0" name="coolantProtTemp" rows="6" units="C">
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+         -33.0 
+      </constant>
+<constant cols="1" digits="0" name="unused179_184" rows="6">
          7.0 
          7.0 
          7.0 
@@ -1670,6 +1690,14 @@
          7.0 
          7.0 
       </constant>
+<constant name="afrProtectEnabled">"Off"</constant>
+<constant digits="0" name="afrProtectMAP" units="kPa">180.0</constant>
+<constant digits="0" name="afrProtectRPM" units="RPM">4000.0</constant>
+<constant digits="1" name="afrProtectTPS" units="%">80.0</constant>
+<constant digits="3" name="afrProtectDeviationLambda" units="Lambda">0.0952381</constant>
+<constant digits="1" name="afrProtectDeviation" units="AFR">1.4</constant>
+<constant digits="1" name="afrProtectCutTime" units="seconds">0.7</constant>
+<constant digits="1" name="afrProtectReactivationTPS" units="%">3.5</constant>
 </page>
 <page number="9" size="192">
 <constant cols="1" digits="0" name="crankingEnrichBins" rows="4" units="C">
@@ -1767,6 +1795,7 @@
 <constant digits="0" name="n2o_maxMAP" units="kPa">250.0</constant>
 <constant digits="1" name="n2o_minTPS" units="%TPS">30.0</constant>
 <constant digits="1" name="n2o_maxAFR" units="AFR">18.0</constant>
+<constant digits="3" name="n2o_maxLambda" units="Lambda">1.2244898</constant>
 <constant name="n2o_stage1_pin">"30"</constant>
 <constant name="n2o_pin_polarity">"LOW"</constant>
 <constant name="n2o_unused">"No"</constant>
@@ -1843,21 +1872,21 @@
 <constant name="oilPressureProtEnbl">"Off"</constant>
 <constant name="oilPressurePin">"A12"</constant>
 <constant name="fuelPressurePin">"A5"</constant>
-<constant digits="0" name="fuelPressureMin" units="psi">52.0</constant>
-<constant digits="0" name="fuelPressureMax" units="psi">158.0</constant>
-<constant digits="0" name="oilPressureMin" units="psi">-66.0</constant>
-<constant digits="0" name="oilPressureMax" units="psi">62.0</constant>
+<constant digits="2" name="fuelPressureMin" units="BAR">-1.6054</constant>
+<constant digits="2" name="fuelPressureMax" units="BAR">15.0768</constant>
+<constant digits="2" name="oilPressureMin" units="BAR">5.4444</constant>
+<constant digits="2" name="oilPressureMax" units="BAR">8.376</constant>
+<constant cols="1" digits="2" name="oilPressureProtMins" rows="4" units="BAR">
+         6.631 
+         4.3974 
+         1.5356 
+         15.1466 
+      </constant>
 <constant cols="1" digits="0" name="oilPressureProtRPM" rows="4" units="RPM">
          12800.0 
          7000.0 
          4400.0 
          18300.0 
-      </constant>
-<constant cols="1" digits="0" name="oilPressureProtMins" rows="4" units="psi">
-         96.0 
-         58.0 
-         73.0 
-         176.0 
       </constant>
 <constant name="wmiEnabled">"Off"</constant>
 <constant name="wmiMode">"Simple"</constant>
@@ -1919,9 +1948,9 @@
 <constant name="spark2InputPin">"3"</constant>
 <constant name="spark2InputPolarity">"LOW"</constant>
 <constant name="spark2InputPullup">"No"</constant>
-<constant cols="1" digits="0" name="unused11_190_191" rows="2" units="RPM">
-         1500.0 
-         500.0 
+<constant digits="1" name="oilPressureProtTime" units="seconds">2.0</constant>
+<constant digits="0" name="unused11_190_191" units="RPM">
+         0.0 
       </constant>
 </page>
 <page number="10" size="288">
@@ -2053,11 +2082,11 @@
          3000.0 
          4000.0 
       </constant>
-<constant cols="1" digits="0" name="mapBinsDwell" rows="4" units="kPa">
-         10.0 
-         50.0 
-         100.0 
-         200.0 
+<constant cols="1" digits="0" name="loadBinsDwell" rows="4" units="kPa">
+         510.0 
+         510.0 
+         510.0 
+         510.0 
       </constant>
 <constant cols="1" digits="0" name="UNALLOCATED_TOP_11" rows="8" units="RAW">
          0.0 
@@ -2241,7 +2270,7 @@
 <constant name="onboard_log_tr3_thr_AFR">"Enabled"</constant>
 <constant digits="2" name="onboard_log_tr4_thr_on" units="V">25.5</constant>
 <constant digits="2" name="onboard_log_tr4_thr_off" units="V">25.5</constant>
-<constant digits="0" name="onboard_log_tr5_thr_on" units="pin">255.0</constant>
+<constant name="unused13_125_2">"space"</constant>
 <constant cols="1" digits="0" name="unused12_125_127" rows="2" units="%">
          255.0 
          255.0 
@@ -2303,8 +2332,230 @@
          240.0 
       </constant>
 </page>
+<page number="14" size="256">
+<constant cols="8" digits="0" name="boostTableDutyLookup" rows="8" units="Duty Cycle %">
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+         50.0 50.0 50.0 50.0 50.0 50.0 50.0 50.0 
+      </constant>
+<constant cols="1" digits="0" name="rpmBinsDutyLookup" rows="8" units="RPM">
+         1500.0 
+         2000.0 
+         2500.0 
+         3000.0 
+         3500.0 
+         4000.0 
+         4500.0 
+         5000.0 
+      </constant>
+<constant cols="1" digits="0" name="loadBinsDutyLookup" rows="8" units="kpa">
+         130.0 
+         140.0 
+         150.0 
+         160.0 
+         170.0 
+         180.0 
+         190.0 
+         200.0 
+      </constant>
+<constant name="boostControlEnable">"Baro"</constant>
+<constant name="unused15_1_1">"False"</constant>
+<constant name="unused15_1_2">"False"</constant>
+<constant name="unused15_1_3">"False"</constant>
+<constant digits="0" name="boostDCWhenDisabled" units="%">0.0</constant>
+<constant digits="0" name="boostControlEnableThreshold" units="kpa">255.0</constant>
+<constant name="airConEnable">"Off"</constant>
+<constant name="airConCompPol">"Inverted"</constant>
+<constant name="airConReqPol">"Inverted"</constant>
+<constant name="airConTurnsFanOn">"Yes"</constant>
+<constant name="airConFanEnabled">"Disabled"</constant>
+<constant name="airConFanPol">"Inverted"</constant>
+<constant name="airConUnused1">"3"</constant>
+<constant name="airConCompPin">"Unused"</constant>
+<constant name="airConUnused2">"3"</constant>
+<constant name="airConReqPin">"Unused"</constant>
+<constant name="airConUnused3">"3"</constant>
+<constant digits="1" name="airConTPSCut" units="%">50.0</constant>
+<constant digits="0" name="airConMinRPM" units="RPM">600.0</constant>
+<constant digits="0" name="airConMaxRPM" units="RPM">4000.0</constant>
+<constant digits="0" name="airConClTempCut" units="C">110.0</constant>
+<constant digits="0" name="airConIdleSteps" units="%/Steps">5.0</constant>
+<constant digits="1" name="airConTPSCutTime" units="s">2.0</constant>
+<constant digits="1" name="airConCompOnDelay" units="s">0.5</constant>
+<constant digits="1" name="airConAfterStartDelay" units="s">5.0</constant>
+<constant digits="1" name="airConRPMCutTime" units="s">2.0</constant>
+<constant name="airConFanPin">"Unused"</constant>
+<constant name="airConUnused4">"3"</constant>
+<constant digits="0" name="airConIdleUpRPMAdder" units="Added Target RPM">100.0</constant>
+<constant digits="1" name="airConPwmFanMinDuty" units="%">40.0</constant>
+<constant cols="1" digits="0" name="Unused15_98_255" rows="158" units="%">
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+         255.0 
+      </constant>
+</page>
 <settings Comment="These setting are only used if this msq is opened without a project.">
-<setting name="NEW_COMMS" value="NEW_COMMS"/>
+<setting name="pressure_bar" value="pressure_bar"/>
 <setting name="enablehardware_test" value="enablehardware_test"/>
 <setting name="CAN_COMMANDS_OFF" value="CAN_COMMANDS_OFF"/>
 <setting name="CELSIUS" value="CELSIUS"/>


### PR DESCRIPTION
Updated BMW tunes to 202305 version. I have some problems with newer FW versions, so I didn't update to those. But this includes some essential settings to make newer FW versions to work.